### PR TITLE
Optimize intercode generation.

### DIFF
--- a/include/intercode.h
+++ b/include/intercode.h
@@ -65,13 +65,6 @@ typedef struct Quad
 
 void generate_intermediate_code(List * code_list, Syntax * top_level);
 
-Quad * quad_new(Operator op);
-void quad_delete(Quad * quad);
-
-void new_label(char *name);
-void new_temp(char *name);
-void new_variable(char *name);
-
 void print_quad_list(FILE *fp, List *code_list);
 
 

--- a/source/main.c
+++ b/source/main.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
+#include <time.h>
 #include "list.h"
 #include "syntax.h"
 #include "scc_yacc.h"
@@ -30,6 +31,8 @@ void read_file()
 
 int main(int argc, char ** argv)
 {
+    clock_t start_time = clock();
+
     char syntax_file_name[50];
     char ir_file_name[50];
 
@@ -122,7 +125,8 @@ int main(int argc, char ** argv)
         print_quad_list(fp, code_list);
     }
 
-    printf("\033[1;32mCompile Success!\033[0m\n");
+    clock_t end_time = clock();
+    printf("\033[1;32mCompile Succeeded in %g seconds!\033[0m\n", (float)(end_time - start_time) / CLOCKS_PER_SEC);
     return 0;
 }
 

--- a/source/scc.y
+++ b/source/scc.y
@@ -623,10 +623,6 @@ in_block_statement:
             Syntax * syntax = syntax_new(RETURN_STATEMENT);
             $$ = syntax;
         }
-        | error ';'
-        {
-            $$ = NULL;
-        }
         ;
 
 if_statement:

--- a/source/semantic.c
+++ b/source/semantic.c
@@ -209,12 +209,13 @@ bool semantic_analysis(Syntax * syntax)
                 print_error(buf, syntax->variable->name, syntax->lineno);
                 is_correct = false;
             }
-            else if(previous_symbol->declaration->type != VARIABLE_DECLARATION)
+            else if(previous_symbol->declaration->type != VARIABLE_DECLARATION || previous_symbol->declaration->variable_declaration->type->variable_type->type == STRUCT)
             {
                 char buf[100];
                 if(previous_symbol->declaration->type == ARRAY_DECLARATION)
                     sprintf(buf, "Require '[]' on array variable");
-                else if(previous_symbol->declaration->type == STRUCT_DECLARATION)
+                else if(previous_symbol->declaration->type == VARIABLE_DECLARATION && 
+                   previous_symbol->declaration->variable_declaration->type->variable_type->type == STRUCT)
                     sprintf(buf, "Require '.' on array variable");
                 else if(previous_symbol->declaration->type == FUNCTION_DECLARATION)
                     sprintf(buf, "Require '()' on function call");

--- a/source/semantic.c
+++ b/source/semantic.c
@@ -55,7 +55,7 @@ Syntax * check_expression_type(Syntax * syntax)
         {
             // wrap the immediate's type
             Syntax * type = syntax_new(VARIABLE_TYPE);
-            type->variable_type->type = IMMEDIATE;
+            type->variable_type->type = syntax->immediate->type;
             return type;
         }
         case VARIABLE:

--- a/source/semantic.c
+++ b/source/semantic.c
@@ -39,8 +39,12 @@ bool is_variable_type_equal(Syntax * type1, Syntax * type2)
 
 Syntax * check_expression_type(Syntax * syntax)
 {
+    // TODO:
+    // the wrapped variable type syntax will not be deleted
+    // after usage, which will cause memory leaks
     if(syntax == NULL)
     {
+        // wrap the void type
         Syntax * type = syntax_new(VARIABLE_TYPE);
         type->variable_type->type = VOID;
         return type;
@@ -51,7 +55,7 @@ Syntax * check_expression_type(Syntax * syntax)
         {
             // wrap the immediate's type
             Syntax * type = syntax_new(VARIABLE_TYPE);
-            type->variable_type->type = syntax->immediate->type;
+            type->variable_type->type = IMMEDIATE;
             return type;
         }
         case VARIABLE:

--- a/source/semantic.c
+++ b/source/semantic.c
@@ -209,6 +209,16 @@ bool semantic_analysis(Syntax * syntax)
                 print_error(buf, syntax->variable->name, syntax->lineno);
                 is_correct = false;
             }
+            else if(previous_symbol->declaration->type != VARIABLE_DECLARATION)
+            {
+                char buf[100];
+                if(previous_symbol->declaration->type == ARRAY_DECLARATION)
+                    sprintf(buf, "Require '[]' on array variable");
+                else if(previous_symbol->declaration->type == STRUCT_DECLARATION)
+                    sprintf(buf, "Require '.' on array variable");
+                else if(previous_symbol->declaration->type == FUNCTION_DECLARATION)
+                    sprintf(buf, "Require '()' on function call");
+            }
             break;
         }
         case ARRAY_DECLARATION:
@@ -246,16 +256,13 @@ bool semantic_analysis(Syntax * syntax)
                 print_error(buf, syntax->array_variable->name, syntax->lineno);
                 is_correct = false;
             }
-            else
+            // '[]' used on non-array variable
+            else if(previous_symbol->declaration->type != ARRAY_DECLARATION)
             {
-                // '[]' used on non-array variable
-                if(previous_symbol->declaration->type != ARRAY_DECLARATION)
-                {
-                    char buf[100];
-                    sprintf(buf, "'[]' used on non-array variable '%s'", syntax->array_variable->name);
-                    print_error(buf, syntax->array_variable->name, syntax->lineno);
-                    is_correct = false;
-                }
+                char buf[100];
+                sprintf(buf, "'[]' used on non-array variable '%s'", syntax->array_variable->name);
+                print_error(buf, syntax->array_variable->name, syntax->lineno);
+                is_correct = false;
             }
             break;
         }


### PR DESCRIPTION
1. Rename the private functions.
2. Make local global variable static.
3. Reset the temp variable counter when expression is fully translated.